### PR TITLE
Added Devicon

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,11 @@ You can follow me on [Twitter](https://twitter.com/vkarampinis).
 
 ### Generic
 - [Batch](http://adamwhitcroft.com/batch/) A lovingly designed and crafted suite of 300+ icons for web and user interface design.
+- [Devicon](https://konpa.github.io/devicon/) a set of icons representing programming languages, designing & development tools. You can use it as a font or directly copy/paste the svg code into your project.
 - [Entypo+](http://www.entypo.com/) 411 carefully crafted premium pictograms.
 - [Erler Dingbats Unicode](http://www.ffdingbatsfont.com/)
 - [Font Awesome](http://fontawesome.io/) Scalable vector icons that can instantly be customized — size, color, drop shadow, and anything that can be done with the power of CSS.
-- [Foundation Icon Fonts 2](http://zurb.com/playground/foundation-icons) 
+- [Foundation Icon Fonts 2](http://zurb.com/playground/foundation-icons)
 - [Foundation Icon Fonts 3](http://zurb.com/playground/foundation-icon-fonts-3) A custom collection of 283 icons.
 - [Glyphicons](http://glyphicons.com/) is a library of precisely prepared monochromatic icons and symbols, created with an emphasis to simplicity and easy orientation.
 - [icoMoon](https://icomoon.io) 490+ free Icons

--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ You can follow me on [Twitter](https://twitter.com/vkarampinis).
 - [Marka](http://fian.my.id/marka/) 36 Beautiful transformable icons.
 - [Octicons](https://octicons.github.com/) Github's icons
 - [Raphaël](http://icons.marekventur.com/)
-- [RPG-Awesome](https://nagoshiashumari.github.io/Rpg-Awesome/) A fantasy themed font and CSS toolkit.
 - [Typicons](http://typicons.com/) 336 pixel perfect, all-purpose vector icons
 - [Google Material Design Icons, by Google](https://design.google.com/icons/) Official Google Material Design Icons
 - [pictonic](https://pictonic.co) Over 260+ free icons

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ You can follow me on [Twitter](https://twitter.com/vkarampinis).
 - [Marka](http://fian.my.id/marka/) 36 Beautiful transformable icons.
 - [Octicons](https://octicons.github.com/) Github's icons
 - [Raphaël](http://icons.marekventur.com/)
+- [RPG-Awesome](https://nagoshiashumari.github.io/Rpg-Awesome/) A fantasy themed font and CSS toolkit.
 - [Typicons](http://typicons.com/) 336 pixel perfect, all-purpose vector icons
 - [Google Material Design Icons, by Google](https://design.google.com/icons/) Official Google Material Design Icons
 - [pictonic](https://pictonic.co) Over 260+ free icons


### PR DESCRIPTION
Devicon is focused just on programming languages and design. It's a little less flexible than FontAwesome, but has more variety of icons for the category it is focused on. It also has the option of having the icons already colored in the standard color for that icon. For instance, the HTML5 icon is automatically orange if your use the colored class for it. 

Anyway, I think it is worthy of this list.

[https://konpa.github.io/devicon/](https://konpa.github.io/devicon/)

---

Secondly, sorry. I accidentally added 2 items to this pull request. I was actually going back to change it and apparently did not commit my deletion of the second link before submitting the original request.

Anyway, the second item is RPG-Awesome. It is a fantasy themed icon set and css toolkit. It works just like FontAwesome, but has a completely different set of icons. It doesn't have a CDN, which makes it a little less convenient. However, it's unlike anything else out there and has a very unique set of icons that I think are also worthy of this list.

https://nagoshiashumari.github.io/Rpg-Awesome/

---

Again, sorry about adding two items to one pull request. 
