### PR TITLE
update link to devicons

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Please read the [contribution guidelines](contributing.md) before contributing
 
 ## Generic
 - [Simple icons](https://simpleicons.org/) - Over 1000 Free SVG icons for popular brands.
-- [Devicon](https://konpa.github.io/devicon/) - A set of icons representing programming languages, designing & development tools. You can use it as a font or directly copy/paste the svg code into your project.
+- [Devicon](https://devicon.dev) - A set of icons representing programming languages, designing & development tools. You can use it as a font or directly copy/paste the svg code into your project.
 - [Feather](https://feathericons.com/) - A collection of simply beautiful open source icons.
 - [Font Awesome](http://fontawesome.io/) - Scalable vector icons that can instantly be customized — size, color, drop shadow, and anything that can be done with the power of CSS.
 - [Foundation Icon Fonts 2](http://zurb.com/playground/foundation-icons)


### PR DESCRIPTION
The original repo has been forked, and moved to https://github.com/devicons/devicon

We currently have two websites: 
- current official website -> https://devicon.dev
- new (soon to be official) website -> https://risbi0.github.io/devicon-new-ui/