### PR TITLE
Remove Jam Icons as its no longer available

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,6 @@ Please read the [contribution guidelines](contributing.md) before contributing
 - [Ant Design Icons, by Ant Financial](https://ant.design/components/icon/) - ⭐ Ant Design SVG Icons.
 - [Boxicons](https://boxicons.com/) - Boxicons is a simple vector icons set carefully crafted for designers and developers to use in your next project.
 - [Eva Icons](https://akveo.github.io/eva-icons/) - Eva Icons is a pack of more than 480 beautifully crafted Open Source icons for common actions and items.
-- [Jam Icons](https://jam-icons.com/) - Jam icons is a set of icons designed for web projects, illustrations, print projects, etc. Shipped in JavaScript, font & SVG versions.
 - [Remix Icon](https://remixicon.com/) - Remix Icon is a set of open-source neutral-style system symbols elaborately crafted for designers and developers.
 - [Themify Icons](https://themify.me/themify-icons) - Themify Icons is a complete set of icons for use in web design and apps, consisting of 320+ pixel-perfect, hand-crafted icons that draw inspiration from Apple iOS 7.
 - [SuperTinyIcons](https://github.com/edent/SuperTinyIcons) - Miniscule SVG versions of website and app logos, under 1KB each.


### PR DESCRIPTION
I noticed that Jam Icons is no longer available, with the author directing people to either Heroicons or Simple Icons, which are bother already on the list.