### PR TITLE
Add TinyTools Favicon Generator to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,3 +108,4 @@ Please read the [contribution guidelines](contributing.md) before contributing
 - [Orion icon library](https://www.orioniconlibrary.com/) - Generate icon fonts or download icons in multiple formats.
 - [Unicon](https://unicon.webrenew.com/) - Browse 20,000+ icons and export as React, Vue, Svelte, or SVG.
 - [Hugeicons Icon Font Generator](https://hugeicons.com/icon-font-generator/) - Generate icon fonts from 46,000+ icons (with license) or use 4,600+ free icons and custom uploaded icons.
+- [TinyTools Favicon Generator](https://tinytools-smoky.vercel.app/) - Free browser-based favicon generator producing all favicon variants (ICO, PNG sizes, Apple touch icon, Android Chrome icons, manifest) from a single image. No signup, runs entirely in browser.


### PR DESCRIPTION
Adds **[TinyTools Favicon Generator](https://tinytools-smoky.vercel.app/)** to the Tools section.

**What it is:** A free, browser-based favicon generator. Upload a single image and instantly download all required favicon variants — ICO, multi-size PNGs, Apple touch icon, Android Chrome icons, and a web manifest. Everything runs in the browser, no signup, no upload to a server.

It sits alongside the icon-font generators already in the Tools section but covers a different use case: the favicon set every web project needs.

Live: https://tinytools-smoky.vercel.app/

Open source. Other free utilities live alongside it (OG image generator, color palette generator, AI background remover, SEO meta generator) on the same page if useful for cross-references.