### PR TITLE
Add SVG to TGS

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,3 +112,4 @@ Please read the [contribution guidelines](contributing.md) before contributing
 - [Unicon](https://unicon.webrenew.com/) - Browse 20,000+ icons and export as React, Vue, Svelte, or SVG.
 - [Hugeicons Icon Font Generator](https://hugeicons.com/icon-font-generator/) - Generate icon fonts from 46,000+ icons (with license) or use 4,600+ free icons and custom uploaded icons.
 - [IconKing](https://iconking.net) - Free browser-based Lottie animation viewer, color editor, and .json/.lottie converter. No account required, 100% client-side.
+- [SVG to TGS](https://svgtotgs.com/) - Animates SVG artwork in the browser and exports Telegram-ready TGS files for animated stickers and custom emoji.


### PR DESCRIPTION
Adds [SVG to TGS](https://svgtotgs.com/) to the **Tools** section. It belongs here because it animates SVG artwork directly in the browser and exports Telegram-ready TGS files for animated stickers and custom emoji.

I checked the existing list and pull requests for duplicates. Disclosure: I represent SVG to TGS.