### PR TITLE
Add FaviconDL to icon tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,3 +112,4 @@ Please read the [contribution guidelines](contributing.md) before contributing
 - [Unicon](https://unicon.webrenew.com/) - Browse 20,000+ icons and export as React, Vue, Svelte, or SVG.
 - [Hugeicons Icon Font Generator](https://hugeicons.com/icon-font-generator/) - Generate icon fonts from 46,000+ icons (with license) or use 4,600+ free icons and custom uploaded icons.
 - [IconKing](https://iconking.net) - Free browser-based Lottie animation viewer, color editor, and .json/.lottie converter. No account required, 100% client-side.
+- [FaviconDL](https://favicondl.com/) - Fetch and download any website's favicon by URL, with multiple sizes and a public API.


### PR DESCRIPTION
I built FaviconDL after repeatedly needing a reliable way to pull the actual favicon behind a site URL while working on launch pages and directories. It resolves the icon, offers multiple sizes, and exposes a public API.

I added it to the bottom of the Tools section using the list's required one-line format.

Link: https://favicondl.com/