### PR TITLE
Add ArtboardLab AI to SVG to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,3 +114,4 @@ Please read the [contribution guidelines](contributing.md) before contributing
 - [IconKing](https://iconking.net) - Free browser-based Lottie animation viewer, color editor, and .json/.lottie converter. No account required, 100% client-side.
 - [SVG to TGS](https://svgtotgs.com/) - Animates SVG artwork in the browser and exports Telegram-ready TGS files for animated stickers and custom emoji.
 - [FaviconDL](https://favicondl.com/) - Fetch and download any website's favicon by URL, with multiple sizes and a public API.
+- [ArtboardLab AI to SVG](https://artboardlab.com/tools/ai-to-svg/) - Converts Adobe Illustrator .ai artwork to SVG without Illustrator, entirely in the browser.


### PR DESCRIPTION
Adds ArtboardLab AI to SVG to the **Tools** section.

**Disclosure: I built this.** It is my own project, submitted per the guideline "Add a link to the package and why it should be included".

**What it is:** a free browser tool that converts Adobe Illustrator `.ai` artwork to SVG — no Illustrator install, no account, no upload. Everything runs in the browser, so the file never leaves your device. Direct tool link, not the site root.

**Why it fits Tools:** icon sets are still routinely delivered as `.ai` source files, and getting them into SVG usually means owning Illustrator. This section already collects in-browser format converters (fontglyph, SVG to TGS, IconKing), and this covers the `.ai` → SVG step that precedes all of them.

**Not a duplicate:** `grep -i "illustrator\|\.ai\b\|artboard" README.md` on master returns no matches — there is currently no Illustrator/`.ai` entry anywhere in the list.

**Guidelines checklist:**
- Single suggestion, single PR
- Format `[name](link) - Description.` — capital start, full stop, no trailing whitespace
- Added at the bottom of the relevant section
- Link is live and free to use

One thing I should flag honestly rather than hide: the guidelines suggest waiting a couple of weeks after launching something. The tool is live and working today, but the site is young — if you would rather I resubmit later, just say so and I will close this and come back.
